### PR TITLE
Use dyn keyword and test with 1.31.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 
 rust:
   - stable
+  - 1.31.1
   - beta
   - nightly
 

--- a/src/liberasurecode.rs
+++ b/src/liberasurecode.rs
@@ -104,6 +104,7 @@ impl LibErasureCoder {
     /// Makes a new `LibErasureCoder` instance with the default settings.
     ///
     /// This is equivalent to `LibErasureCoderBuilder::new(data_fragments, parity_fragments).build_coder()`.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(data_fragments: NonZeroUsize, parity_fragments: NonZeroUsize) -> Result<Self> {
         track!(LibErasureCoderBuilder::new(data_fragments, parity_fragments).build_coder())
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -7,7 +7,7 @@ use trackable::error::ErrorKindExt;
 use {BuildCoder, ErasureCode, Error, ErrorKind, Fragment, FragmentBuf, Result};
 
 thread_local! {
-    static ERASURE_CODERS: RefCell<HashMap<String, Box<ErasureCode>>> =
+    static ERASURE_CODERS: RefCell<HashMap<String, Box<dyn ErasureCode>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -81,7 +81,7 @@ impl<B: BuildCoder> ErasureCoderPool<B> {
 
     fn with_coder<F, T>(builder: &B, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(&'a mut ErasureCode) -> Result<T>,
+        for<'a> F: FnOnce(&'a mut dyn ErasureCode) -> Result<T>,
     {
         ERASURE_CODERS.with(|coders| {
             let coder_id = builder.coder_id();


### PR DESCRIPTION
When using bare trait, the current *beta* compiler emits errors like the following:
```
error: trait objects without an explicit `dyn` are deprecated
  --> src/pool.rs:10:56
   |
10 |     static ERASURE_CODERS: RefCell<HashMap<String, Box<ErasureCode>>> =
   |                                                        ^^^^^^^^^^^ help: use `dyn`: `dyn ErasureCode`
error: trait objects without an explicit `dyn` are deprecated
  --> src/pool.rs:84:35
   |
84 |         for<'a> F: FnOnce(&'a mut ErasureCode) -> Result<T>,
   |                                   ^^^^^^^^^^^ help: use `dyn`: `dyn ErasureCode`
```

This PR adds `dyn` keywords and suppress these warnings. Because the `dyn` keyword is introduced in 1.27, this also compiles in rustc 1.31.1.

In addition, this PR adds a test against rustc 1.31.1.

## Information
Compiler versions
```
$ rustc --version
rustc 1.37.0-beta.2 (74e5a0d47 2019-07-08)
$ rustup --version
rustup 1.18.3 (435397f48 2019-05-22)
$ cargo --version
cargo 1.37.0-beta (4c1fa54d1 2019-06-24)
```